### PR TITLE
test: Investigate removing IsEmptyInterface

### DIFF
--- a/__snapshots__/IsEmptyInterface
+++ b/__snapshots__/IsEmptyInterface
@@ -1,15 +1,14 @@
-sources/IsEmptyInterface.test.ts(11,27): error TS2554: Expected 1 arguments, but got 0.
 Files:            54
-Lines:         61523
-Nodes:        180439
-Identifiers:   62593
-Symbols:      104001
-Types:         36907
-Memory used: 133717K
-I/O read:      0.02s
+Lines:         61486
+Nodes:        180332
+Identifiers:   62560
+Symbols:      103229
+Types:         36758
+Memory used: 152281K
+I/O read:      0.01s
 I/O write:     0.00s
-Parse time:    0.68s
-Bind time:     0.76s
-Check time:    3.13s
+Parse time:    0.57s
+Bind time:     0.23s
+Check time:    3.68s
 Emit time:     0.00s
-Total time:    4.57s
+Total time:    4.48s

--- a/__snapshots__/IsEmptyInterface
+++ b/__snapshots__/IsEmptyInterface
@@ -1,14 +1,14 @@
 Files:            54
-Lines:         61486
-Nodes:        180332
-Identifiers:   62560
-Symbols:      103229
-Types:         36758
-Memory used: 152281K
-I/O read:      0.01s
+Lines:         61464
+Nodes:        180242
+Identifiers:   62543
+Symbols:      103216
+Types:         36751
+Memory used: 152222K
+I/O read:      0.02s
 I/O write:     0.00s
-Parse time:    0.57s
-Bind time:     0.23s
-Check time:    3.68s
+Parse time:    0.62s
+Bind time:     0.24s
+Check time:    3.11s
 Emit time:     0.00s
-Total time:    4.48s
+Total time:    3.97s

--- a/vendor/@material-ui/styles/makeStyles/makeStyles.d.ts
+++ b/vendor/@material-ui/styles/makeStyles/makeStyles.d.ts
@@ -5,26 +5,9 @@ import {
   Styles,
   WithStylesOptions,
 } from '@material-ui/styles/withStyles';
-import { Omit, IsAny, Or, IsEmptyInterface } from '@material-ui/types';
+import { Omit } from '@material-ui/types';
 import { DefaultTheme } from '../defaultTheme';
 
-/**
- * @internal
- *
- * If a style callback is given with `theme => stylesOfTheme` then typescript
- * infers `Props` to `any`.
- * If a static object is given with { ...members } then typescript infers `Props`
- * to `{}`.
- *
- * So we require no props in `useStyles` if `Props` in `makeStyles(styles)` is
- * inferred to either `any` or `{}`
- */
-export type StylesRequireProps<S> = Or<
-  IsAny<PropsOfStyles<S>>,
-  IsEmptyInterface<PropsOfStyles<S>>
-> extends true
-  ? false
-  : true;
 
 /**
  * @internal
@@ -33,9 +16,7 @@ export type StylesRequireProps<S> = Or<
  * from which the typechecker could infer a type so it falls back to `any`.
  * See the test cases for examples and implications of explicit `any` annotation
  */
-export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> extends false
-  ? (props?: any) => ClassNameMap<ClassKeyOfStyles<S>>
-  : (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
+export type StylesHook<S extends Styles<any, any>> = (props?: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>
 
 export default function makeStyles<
   Theme = DefaultTheme,

--- a/vendor/@material-ui/styles/withStyles/withStyles.d.ts
+++ b/vendor/@material-ui/styles/withStyles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector, IsEmptyInterface } from '@material-ui/types';
+import { PropInjector } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 import { DefaultTheme } from '../defaultTheme';
@@ -43,9 +43,7 @@ export interface CreateCSSProperties<Props extends object = {}>
  */
 export type StyleRules<Props extends object = {}, ClassKey extends string = string> = Record<
   ClassKey,
-  IsEmptyInterface<Props> extends true
-    ? CSSProperties | (() => CSSProperties)
-    : CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
+  CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
 >;
 
 /**

--- a/vendor/@material-ui/types/index.d.ts
+++ b/vendor/@material-ui/types/index.d.ts
@@ -44,25 +44,3 @@ export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof
  * @internal
  */
 export type Overwrite<T, U> = Omit<T, keyof U> & U;
-
-/**
- * Returns true if T is any, otherwise false
- */
-// https://stackoverflow.com/a/49928360/3406963 without generic branch types
-export type IsAny<T> = 0 extends (1 & T) ? true : false;
-
-export type Or<A, B, C = false> = A extends true
-  ? true
-  : B extends true
-  ? true
-  : C extends true
-  ? true
-  : false;
-
-export type And<A, B, C = true> = A extends true
-  ? B extends true
-    ? C extends true
-      ? true
-      : false
-    : false
-  : false;

--- a/vendor/@material-ui/types/index.d.ts
+++ b/vendor/@material-ui/types/index.d.ts
@@ -66,19 +66,3 @@ export type And<A, B, C = true> = A extends true
       : false
     : false
   : false;
-
-/**
- * @internal
- *
- * check if a type is `{}`
- *
- * 1. false if the given type has any members
- * 2. false if the type is `object` which is the only other type with no members
- *  {} is a top type so e.g. `string extends {}` but not `string extends object`
- * 3. false if the given type is `unknown`
- */
-export type IsEmptyInterface<T> = And<
-  keyof T extends never ? true : false,
-  string extends T ? true : false,
-  unknown extends T ? false : true
->;


### PR DESCRIPTION
Removes `IsEmptyInterface`. There are slight reductions in the number of Nodes, Identifiers, Symbols and Types but `yarn perf:IsEmptyInterface` does not yield a significant improvement:
- `4.52478006190000000000 seconds per run seconds per run` on master compared to 
- `4.27613066370000000000 seconds per run` on this branch
- resulting in `0.2486493982` reduction or 6%.

Maybe we need to improve other areas first to see a significant improvement (e.g. BaseCSSProperties). Maybe we need a larger codebase to check.

/cc @amcasey