### PR TITLE
test: untyped pseudo selectors

### DIFF
--- a/__snapshots__/IsEmptyInterface
+++ b/__snapshots__/IsEmptyInterface
@@ -1,15 +1,15 @@
 sources/IsEmptyInterface.test.ts(11,27): error TS2554: Expected 1 arguments, but got 0.
 Files:            54
-Lines:         61537
-Nodes:        180301
-Identifiers:   62579
-Symbols:      101171
-Types:         33804
-Memory used: 147062K
+Lines:         61535
+Nodes:        180284
+Identifiers:   62572
+Symbols:       99657
+Types:         33792
+Memory used: 134494K
 I/O read:      0.01s
 I/O write:     0.00s
-Parse time:    0.59s
-Bind time:     0.24s
-Check time:    3.50s
+Parse time:    0.64s
+Bind time:     0.25s
+Check time:    3.04s
 Emit time:     0.00s
-Total time:    4.33s
+Total time:    3.92s

--- a/vendor/@material-ui/styles/withStyles/withStyles.d.ts
+++ b/vendor/@material-ui/styles/withStyles/withStyles.d.ts
@@ -17,7 +17,7 @@ export interface BaseCSSProperties extends CSS.Properties<number | string> {
 }
 
 export interface CSSProperties extends BaseCSSProperties {
-  // Allow pseudo selectors and media queries
+  // Allow untyped pseudo selectors and media queries
   // `unknown` is used since TS does not allow assigning an interface without
   // an index signature to one with an index signature. This is to allow type safe
   // module augmentation.
@@ -25,7 +25,7 @@ export interface CSSProperties extends BaseCSSProperties {
   // `CSSProperties` but this doesn't work. The index signature needs to cover
   // BaseCSSProperties as well. Usually you would use `BaseCSSProperties[keyof BaseCSSProperties]`
   // but this would not allow assigning React.CSSProperties to CSSProperties
-  [k: string]: unknown | CSSProperties;
+  [k: string]: unknown;
 }
 
 export type BaseCreateCSSProperties<Props extends object = {}> = {
@@ -34,10 +34,8 @@ export type BaseCreateCSSProperties<Props extends object = {}> = {
 
 export interface CreateCSSProperties<Props extends object = {}>
   extends BaseCreateCSSProperties<Props> {
-  // Allow pseudo selectors and media queries
-  [k: string]:
-    | BaseCreateCSSProperties<Props>[keyof BaseCreateCSSProperties<Props>]
-    | CreateCSSProperties<Props>;
+  // Allow untyped pseudo selectors and media queries
+  [k: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
`yarn perf:IsEmptyInterface`:

`master` in red, this PR in green:

```diff
-5.16963385680000000000 seconds per run
+4.43769393070000000000 seconds per run
```
So about 15% faster which doesn't seem worth it to me.